### PR TITLE
Activate sidebar by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,8 +103,7 @@
             </div>
 
             <div class="slide-bar">
-                <button class="slide-toggle">Sidebar &ouml;ffnen</button>
-                <div class="side-panel">
+                <div class="side-panel show">
                     <p>Seitenleiste mit Platzhalterinhalten.</p>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -112,10 +112,8 @@ if (dropToggle && dropContent) {
 }
 
 // Slide bar / sidebar
-const slideToggle = document.querySelector('.slide-toggle');
 const sidePanel = document.querySelector('.side-panel');
-if (slideToggle && sidePanel) {
-    slideToggle.addEventListener('click', () => {
-        sidePanel.classList.toggle('show');
-    });
+if (sidePanel) {
+    // ensure sidebar is visible on load
+    sidePanel.classList.add('show');
 }


### PR DESCRIPTION
## Summary
- display the sidebar without needing the toggle button
- keep JS simple by always adding `show` on load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866a24ec8f08328925dbdb7623a2c6d