### PR TITLE
Animate skills bars on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,9 +48,9 @@
             </div>
             <div class="skills">
                 <h3>Skills</h3>
-                <div class="skill"><span>HTML</span><div class="progress"><div style="width:90%"></div></div></div>
-                <div class="skill"><span>CSS</span><div class="progress"><div style="width:85%"></div></div></div>
-                <div class="skill"><span>JavaScript</span><div class="progress"><div style="width:80%"></div></div></div>
+                <div class="skill"><span>HTML</span><div class="progress"><div data-width="90%"></div></div></div>
+                <div class="skill"><span>CSS</span><div class="progress"><div data-width="85%"></div></div></div>
+                <div class="skill"><span>JavaScript</span><div class="progress"><div data-width="80%"></div></div></div>
             </div>
         </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -74,6 +74,24 @@ const observer = new IntersectionObserver(entries => {
 
 document.querySelectorAll('.section').forEach(sec => observer.observe(sec));
 
+// Animate skill bars when they enter the viewport
+const skillsSection = document.querySelector('#about .skills');
+if (skillsSection) {
+    const skillBars = skillsSection.querySelectorAll('.progress div');
+    const skillObserver = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                skillBars.forEach(bar => {
+                    const w = bar.dataset.width;
+                    if (w) bar.style.width = w;
+                });
+                skillObserver.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.3 });
+    skillObserver.observe(skillsSection);
+}
+
 // Carousel functionality
 const track = document.querySelector('.carousel-track');
 if (track) {

--- a/style.css
+++ b/style.css
@@ -185,6 +185,8 @@ body.futuristic .btn:hover {
 .skills .progress div {
     background: var(--primary);
     height: 100%;
+    width: 0;
+    transition: width 0.8s ease;
 }
 
 .filter {


### PR DESCRIPTION
## Summary
- trigger skill bar animations when the skills section enters the viewport
- start progress bars at 0 width with a smooth transition

## Testing
- `npm test` *(fails: package.json missing)*
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6866a2bf57a48328926f9163a9852a14